### PR TITLE
Changes to significance testing and summary plot (#200)

### DIFF
--- a/pyleoclim/tests/test_ui_Series.py
+++ b/pyleoclim/tests/test_ui_Series.py
@@ -233,7 +233,7 @@ class TestUiSeriesSpectral:
         scal = ts.wavelet()
         signif = scal.signif_test(number=2,export_scal = True)
         sig_psd = ts.spectral(method='wwz',scalogram=scal)
-        sig_psd.signif_test(number=2,signif_scals=signif.signif_scals).plot()
+        sig_psd.signif_test(number=2,scalogram=signif).plot()
 
 class TestUiSeriesBin:
     ''' Tests for Series.bin()


### PR DESCRIPTION
* Create contribution_guide.rst

* Update contribution_guide.rst

* Update test_ui_LipdSeries.py

* Update ui.py

* Summary_plot() Update

Added additional key word arguments for psd and scalogram generation as well as the ts, psd, and scalogram subplots.

* Update ui.py

* Update ui.py

* Update ui.py

* Update ui.py

* Update ui.py

* Update test_ui_Series.py

* Update ui.py

* Update ui.py

* Update ui.py

* Update test_ui_Series.py

* Update test_ui_Series.py

* Update ui.py

* Update ui.py

* Update ui.py

* Update ui.py

* Update ui.py

* Update ui.py

* some unit test fixes

* unit test fixes

* export scalogram significance test scalograms

* tests and scalogram progress

* scalogram sharing + unit tests

* summary plot arg fix

* Summary plot ylabel fix

Added an argument y_label_loc to allow for manual offsetting of ylabels if they conflict with tick numbers. Also aligns scalogram and timeseries y label

* Update ui.py

* Update ui.py

* spectral significance test updates

Improved how multipleseries.spectral and thus how spectral.signif_test manages passed scalograms. Now uses what is passed regardless of how many significance tests are called for.

* Summary plot fixes

Improved how robust summary plot is to different configurations. Maximizes efficiency depending on the configuration of scalogram, psd, and n_signif_tests passed.